### PR TITLE
fix preferredStyle not being set

### DIFF
--- a/Source/MockUIAlertController/UIAlertController+QCOMock.m
+++ b/Source/MockUIAlertController/UIAlertController+QCOMock.m
@@ -11,6 +11,7 @@ NSString *const QCOMockAlertControllerPresentedNotification = @"QCOMockAlertCont
 
 @interface UIAlertController ()
 @property (nonatomic, strong) QCOMockPopoverPresentationController *qcoMock_mockPopover;
+@property (nonatomic, readwrite) UIAlertControllerStyle preferredStyle;
 @end
 
 
@@ -40,6 +41,7 @@ NSString *const QCOMockAlertControllerPresentedNotification = @"QCOMockAlertCont
     {
         self.title = title;
         self.message = message;
+        self.preferredStyle = style;
         self.qcoMock_preferredAlertStyle = style;
         self.qcoMock_mockPopover = [[QCOMockPopoverPresentationController alloc] init];
     }


### PR DESCRIPTION
preferredStyle was not being set when creating the AleretController causing an exception to be thrown when trying to add a textfield (requires style to be UIAlertControllerStyleAlert)
