### PR TITLE
Fixed UIViewController swizzle always calling Notification

### DIFF
--- a/Sample/SampleApp/Base.lproj/Main.storyboard
+++ b/Sample/SampleApp/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -26,7 +27,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="W0M-xH-y3m">
-                                <rect key="frame" x="235" y="285" width="131" height="30"/>
+                                <rect key="frame" x="235" y="285" width="130" height="30"/>
                                 <state key="normal" title="Show Action Sheet">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -34,10 +35,21 @@
                                     <action selector="showActionSheet:" destination="BYZ-38-t0r" eventType="touchUpInside" id="01V-Qz-Cw6"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5od-ce-xOg">
+                                <rect key="frame" x="222" y="329" width="156" height="30"/>
+                                <state key="normal" title="Show Modal Controller">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="showModalController:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ESY-Tz-Gq5"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
+                            <constraint firstItem="5od-ce-xOg" firstAttribute="top" secondItem="W0M-xH-y3m" secondAttribute="bottom" constant="14" id="9Kh-No-i0R"/>
                             <constraint firstAttribute="centerX" secondItem="W0M-xH-y3m" secondAttribute="centerX" id="D3n-Oc-uWe"/>
+                            <constraint firstItem="5od-ce-xOg" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="m4l-vO-vMe"/>
                             <constraint firstItem="W0M-xH-y3m" firstAttribute="top" secondItem="v4x-NS-Ot4" secondAttribute="bottom" constant="14" id="nia-fZ-pbU"/>
                             <constraint firstAttribute="centerX" secondItem="v4x-NS-Ot4" secondAttribute="centerX" id="oUW-vi-OAT"/>
                             <constraint firstAttribute="centerY" secondItem="W0M-xH-y3m" secondAttribute="centerY" id="usD-NG-hil"/>
@@ -50,6 +62,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="100" y="429"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="Ddd-cA-AO9">
+            <objects>
+                <viewController storyboardIdentifier="ModalViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="IT4-Xx-owZ" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="dJ6-Wy-iaV"/>
+                        <viewControllerLayoutGuide type="bottom" id="Ka7-LX-GbS"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="ld1-10-p4l">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Kn0-Ur-Qv2" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="796" y="429"/>
         </scene>
     </scenes>
 </document>

--- a/Sample/SampleApp/ViewController.h
+++ b/Sample/SampleApp/ViewController.h
@@ -11,5 +11,6 @@
 
 - (IBAction)showAlert:(id)sender;
 - (IBAction)showActionSheet:(id)sender;
+- (IBAction)showModalController:(id)sender;
 
 @end

--- a/Sample/SampleApp/ViewController.m
+++ b/Sample/SampleApp/ViewController.m
@@ -30,6 +30,14 @@
     [self presentViewController:alertController animated:YES completion:nil];
 }
 
+- (IBAction)showModalController:(id)sender
+{
+  UIViewController *modalController = [self.storyboard instantiateViewControllerWithIdentifier:@"ModalViewController"];
+  [self presentViewController:modalController
+                     animated:true
+                   completion:nil];
+}
+
 - (void)setUpActionsForAlertController:(UIAlertController *)alertController
 {
     self.alertDefaultActionExecuted = NO;

--- a/Sample/Tests/ViewControllerTests-PlainXCTest.m
+++ b/Sample/Tests/ViewControllerTests-PlainXCTest.m
@@ -256,4 +256,13 @@
     XCTAssertEqual(alertVerifier.popover.permittedArrowDirections, UIPopoverArrowDirectionAny);
 }
 
+- (void)testShowModalController_NotTracked
+{
+  QCOMockAlertVerifier *alertVerifier = [[QCOMockAlertVerifier alloc] init];
+  
+  [sut showModalController:nil];
+
+  XCTAssertNil(alertVerifier.message);
+}
+
 @end

--- a/Source/MockUIAlertController.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Source/MockUIAlertController.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Source/MockUIAlertController/UIViewController+QCOMock.m
+++ b/Source/MockUIAlertController/UIViewController+QCOMock.m
@@ -21,12 +21,14 @@ NSString *const QCOMockViewControllerAnimatedKey = @"QCOMockViewControllerAnimat
                              animated:(BOOL)flag
                            completion:(void (^)(void))completion
 {
+  if ([viewControllerToPresent isKindOfClass:[UIAlertController class]]) {
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc postNotificationName:QCOMockAlertControllerPresentedNotification
                       object:viewControllerToPresent
                     userInfo:@{ QCOMockViewControllerAnimatedKey : @(flag) }];
     if (completion)
         completion();
+  }
 }
 
 @end


### PR DESCRIPTION
Previously the presentation of any type of controller from within a UIViewController would result in the AlertController notification being fired.
This caused failures if there was something other than a UIAlertController being presented as there is no property, such as `message`, on a UIViewController

Adding a check for UIAlertController class fixes this issue and now the notification only fires when the presented class is a UIAlertController
