### PR TITLE
Share scheme for Carthage builds

### DIFF
--- a/Source/MockUIAlertController.xcodeproj/xcshareddata/xcschemes/MockUIAlertController.xcscheme
+++ b/Source/MockUIAlertController.xcodeproj/xcshareddata/xcschemes/MockUIAlertController.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0930"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "48007C782079A76E007A4AB0"
+               BuildableName = "MockUIAlertController.framework"
+               BlueprintName = "MockUIAlertController"
+               ReferencedContainer = "container:MockUIAlertController.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "48007C782079A76E007A4AB0"
+            BuildableName = "MockUIAlertController.framework"
+            BlueprintName = "MockUIAlertController"
+            ReferencedContainer = "container:MockUIAlertController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "48007C782079A76E007A4AB0"
+            BuildableName = "MockUIAlertController.framework"
+            BlueprintName = "MockUIAlertController"
+            ReferencedContainer = "container:MockUIAlertController.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
To address Carthage error:
```
*** Skipped building MockUIAlertController due to the error:
Dependency "MockUIAlertController" has no shared framework schemes
```

Sharing the default scheme generated by Xcode:
<img width="737" alt="sahred" src="https://user-images.githubusercontent.com/543851/40671718-4a17cc48-6332-11e8-8e55-8499a735fdf9.png">

Addresses #12. Let me know if there is anything else you need me to do, thanks!

